### PR TITLE
Improved installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,29 @@
 
 ***CouchDB library for [Kitura](https://github.com/IBM-Swift/Kitura)***
 
-This library extends allows Kitura applications to interact with a CouchDB database.
+This library allows Kitura applications to interact with a CouchDB database.
 
 Depends on [Kitura-router](https://github.com/IBM-Swift/Kitura-router).
 
 ## Build CouchDBSample:
 
-  - `swift build -Xcc -fblocks -Xswiftc -I/usr/local/include -Xlinker -L/usr/local/lib` (Mac OS X)
-  - `swift build -Xcc -fblocks` (Linux)
+1. [Download CouchDB](http://couchdb.apache.org/#download) and install.
+
+2. Set up an admin username and password in CouchDB.
+
+3. Create a database with the name `kitura_test_db`.
+
+2. Open a Terminal window to the `Kitura-CouchDB` folder and run `make`:
+
+	```bash
+	make
+	```
+
+3. Run the CouchDBSample executable, passing in your admin username and password:
+
+	```bash
+	.build/debug/CouchDBSample 127.0.0.1 ADMIN_USERNAME ADMIN_PASSWORD
+	```
 
 ## Usage:
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,28 @@ Depends on [Kitura-router](https://github.com/IBM-Swift/Kitura-router).
 
 3. Create a database with the name `kitura_test_db`.
 
-2. Open a Terminal window to the `Kitura-CouchDB` folder and run `make`:
+4. Update the following code in `main.swift` with your admin username and password:
+
+	```swift
+	let connProperties = ConnectionProperties(
+    	host: "127.0.0.1",  // httpd address
+    	port: 5984,         // httpd port
+    	secured: false,     // https or http
+    	username: nil,      // admin username
+    	password: nil       // admin password
+	)
+	```
+
+5. Open a Terminal window to the `Kitura-CouchDB` folder and run `make`:
 
 	```bash
 	make
 	```
 
-3. Run the CouchDBSample executable, passing in your admin username and password:
+6. Run the CouchDBSample executable:
 
 	```bash
-	.build/debug/CouchDBSample 127.0.0.1 ADMIN_USERNAME ADMIN_PASSWORD
+	.build/debug/CouchDBSample
 	```
 
 ## Usage:

--- a/Sources/CouchDB/ConnectionProperties.swift
+++ b/Sources/CouchDB/ConnectionProperties.swift
@@ -18,60 +18,59 @@ import Foundation
 
 // MARK: ConnectionProperties
 
-public class ConnectionProperties {
+public struct ConnectionProperties {
 
-  // Hostname or IP address to the CouchDB server
-  public let hostName: String
+    // Hostname or IP address to the CouchDB server
+    public let host: String
+    
+    // Port number where CouchDB server is listening for incoming connections
+    public let port: Int16
+    
+    // Whether or not to use a secured connection
+    public let secured: Bool
+    
+    
+    
+    // MARK: Authentication credentials to access CouchDB
+    
+    // CouchDB admin username
+    let username: String
+    
+    // CouchDB admin password
+    let password: String
+    
+    
+    public init(host: String, port: Int16, secured: Bool, username: String, password: String) {
+        self.host = host
+        self.port = port
+        self.secured = secured
+        self.username = username
+        self.password = password
+    }
 
-  // Port number where CouchDB server is listening for incoming connections
-  public let port: Int16
+    
+    // MARK: Computed properties
+    
+    // Use https or http
+    var HTTPProtocol: String {
+        return secured ? "https" : "http"
+    }
+    
+    // CouchDB URL
+    var URL: String {
+        return "\(HTTPProtocol)://\(username):\(password)@\(host):\(port)"
+    }
+}
 
-  // Seucred boolean
-  public let secured: Bool
+// MARK: Extension for <CustomStringConvertible>
 
-  // Authentication credentials to access Cloudant
-  // Cloudant username
-  let userName: String?
-
-  // Cloudant password
-  let password: String?
-
-  // Cloudant URL
-  // Derived instance variable
-  let url: String?
-
-  public init(hostName: String, port: Int16, secured: Bool, userName: String?, password: String?) {
-      self.hostName = hostName
-      self.port = port
-      self.userName = userName
-      self.password = password
-      self.secured = secured
-      let httpProtocol = ConnectionProperties.deriveHttpProtocol(secured)
-      if userName != nil && password != nil {
-        self.url = "\(httpProtocol)://\(userName):\(password)\(hostName):\(port)"
-      } else {
-        self.url = "\(httpProtocol)://\(hostName):\(port)"
-      }
-  }
-
-  public convenience init(hostName: String, port: Int16, secured: Bool) {
-    self.init(hostName: hostName, port: port, secured: secured, userName: nil, password: nil)
-  }
-
-  public func toString() -> String {
-    let user = self.userName != nil ? self.userName : ""
-    let pwd = self.password != nil ? self.password : ""
-    let str = "\thostName -> \(hostName)\n" +
-      "\tport -> \(port)\n" +
-      "\tsecured -> \(secured)\n" +
-      "\tuserName -> \(user)\n" +
-      "\tpassword -> \(pwd)"
-    return str
-  }
-
-  static func deriveHttpProtocol(secured: Bool) -> String {
-    let httpProtocol = (secured) ? "https" : "http"
-    return httpProtocol
-  }
-
+extension ConnectionProperties: CustomStringConvertible {
+    public var description:String {
+        return  "\thost -> \(host)\n" +
+                "\tport -> \(port)\n" +
+                "\tsecured -> \(secured)\n" +
+                "\tusername -> \(username)\n" +
+                "\tpassword -> \(password)\n" +
+                "\tURL -> \(URL)"
+    }
 }

--- a/Sources/CouchDB/ConnectionProperties.swift
+++ b/Sources/CouchDB/ConnectionProperties.swift
@@ -16,6 +16,8 @@
 
 import Foundation
 
+import LoggerAPI
+
 // MARK: ConnectionProperties
 
 public struct ConnectionProperties {
@@ -34,18 +36,21 @@ public struct ConnectionProperties {
     // MARK: Authentication credentials to access CouchDB
     
     // CouchDB admin username
-    let username: String
+    let username: String?
     
     // CouchDB admin password
-    let password: String
+    let password: String?
     
     
-    public init(host: String, port: Int16, secured: Bool, username: String, password: String) {
+    public init(host: String, port: Int16, secured: Bool, username: String?, password: String?) {
         self.host = host
         self.port = port
         self.secured = secured
         self.username = username
         self.password = password
+        if self.username == nil || self.password == nil {
+            Log.warning("Initializing a CouchDB connection without a username or password.")
+        }
     }
 
     
@@ -58,7 +63,11 @@ public struct ConnectionProperties {
     
     // CouchDB URL
     var URL: String {
-        return "\(HTTPProtocol)://\(username):\(password)@\(host):\(port)"
+        if let username = username, let password = password {
+            return "\(HTTPProtocol)://\(username):\(password)@\(host):\(port)"
+        } else {
+            return "\(HTTPProtocol)://\(host):\(port)"
+        }
     }
 }
 

--- a/Sources/CouchDB/CouchDBUtils.swift
+++ b/Sources/CouchDB/CouchDBUtils.swift
@@ -54,13 +54,16 @@ class CouchDBUtils {
         }
         return createError(code, id: id, rev: rev)
     }
-
-    class func prepareRequest(connProperties: ConnectionProperties, method: String, path: String,
-        hasBody: Bool, contentType: String = "application/json") -> [ClientRequestOptions] {
+    
+    class func prepareRequest(connProperties: ConnectionProperties, method: String, path: String, hasBody: Bool, contentType: String = "application/json") -> [ClientRequestOptions] {
         var requestOptions = [ClientRequestOptions]()
-
-        requestOptions.append(.Username(connProperties.username))
-        requestOptions.append(.Password(connProperties.password))
+        
+        if let username = connProperties.username {
+            requestOptions.append(.Username(username))
+        }
+        if let password = connProperties.password {
+            requestOptions.append(.Password(password))
+        }
         requestOptions.append(.Hostname(connProperties.host))
         requestOptions.append(.Port(connProperties.port))
         requestOptions.append(.Method(method))

--- a/Sources/CouchDB/CouchDBUtils.swift
+++ b/Sources/CouchDB/CouchDBUtils.swift
@@ -59,15 +59,9 @@ class CouchDBUtils {
         hasBody: Bool, contentType: String = "application/json") -> [ClientRequestOptions] {
         var requestOptions = [ClientRequestOptions]()
 
-        if let userName = connProperties.userName {
-          requestOptions.append(.Username(userName))
-        }
-
-        if let password = connProperties.password {
-          requestOptions.append(.Password(password))
-        }
-
-        requestOptions.append(.Hostname(connProperties.hostName))
+        requestOptions.append(.Username(connProperties.username))
+        requestOptions.append(.Password(connProperties.password))
+        requestOptions.append(.Hostname(connProperties.host))
         requestOptions.append(.Port(connProperties.port))
         requestOptions.append(.Method(method))
         requestOptions.append(.Path(path))

--- a/Sources/CouchDBSample/main.swift
+++ b/Sources/CouchDBSample/main.swift
@@ -39,7 +39,7 @@ let password = args[2]
 
 // Connection properties for testing Cloudant or CouchDB instance
 let connProperties = ConnectionProperties(hostName: hostName,
-  port: 80, secured: false,
+  port: 5984, secured: false,
   userName: userName,
   password: password)
 
@@ -51,7 +51,7 @@ let couchDBClient = CouchDBClient(connectionProperties: connProperties)
 print("Hostname is: \(couchDBClient.connProperties.hostName)")
 
 // Create database instance to perform any document operations
-let database = couchDBClient.database("phoenix_db")
+let database = couchDBClient.database("kitura_test_db")
 
 // Document ID
 let documentId = "123456"

--- a/Sources/CouchDBSample/main.swift
+++ b/Sources/CouchDBSample/main.swift
@@ -94,7 +94,7 @@ func deleteDocument(revisionNumber: String) {
     callback: { (error: NSError?) in
         if let error = error {
             Log.error(">> Oops something went wrong; could not delete document.")
-            Log.error(error.localizedDescription)
+            Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
         } else {
             Log.info(">> Successfully deleted the JSON document with ID \(documentId) from CouchDB.")
         }
@@ -109,7 +109,7 @@ func updateDocument(revisionNumber: String) {
     callback: { (rev: String?, document: JSON?, error: NSError?) in
         if let error = error {
             Log.error(">> Oops something went wrong; could not update document.")
-            Log.error(error.localizedDescription)
+            Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
         } else {
             Log.info(">> Successfully updated the JSON document with ID" +
                 "\(documentId) in CouchDB:\n\t\(document)")
@@ -123,7 +123,7 @@ func readDocument() {
   database.retrieve(documentId, callback: { (document: JSON?, error: NSError?) in
     if let error = error {
       Log.error("Oops something went wrong; could not read document.")
-      Log.error(error.localizedDescription)
+      Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
     } else {
       Log.info(">> Successfully read the following JSON document with ID " +
             "\(documentId) from CouchDB:\n\t\(document)")
@@ -137,7 +137,7 @@ func createDocument() {
   database.create(json, callback: { (id: String?, rev: String?, document: JSON?, error: NSError?) in
     if let error = error {
       Log.error(">> Oops something went wrong; could not persist document.")
-      Log.error(error.localizedDescription)
+      Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
     } else {
       Log.info(">> Successfully created the following JSON document in CouchDB:\n\t\(document)")
       readDocument()

--- a/Sources/CouchDBSample/main.swift
+++ b/Sources/CouchDBSample/main.swift
@@ -23,36 +23,36 @@
 import Foundation
 import SwiftyJSON
 import CouchDB
-
 import LoggerAPI
 import HeliumLogger
 
 Log.logger = HeliumLogger()
-
 Log.info("Starting sample program...")
 
 // Parse runtime args... this is just an interim solution
 let args = Array(Process.arguments[1..<Process.arguments.count])
 if args.count != 3 {
-  Log.error("Hostname, username and password are required as arguments!")
-  exit(1)
+    Log.error("Hostname, username and password are required as arguments!")
+    exit(1)
 }
-let hostName = args[0]
-let userName = args[1]
+let host = args[0]
+let username = args[1]
 let password = args[2]
 
 // Connection properties for testing Cloudant or CouchDB instance
-let connProperties = ConnectionProperties(hostName: hostName,
-  port: 5984, secured: false,
-  userName: userName,
-  password: password)
+let connProperties = ConnectionProperties(
+    host: host,
+    port: 5984,
+    secured: false,
+    username: username,
+    password: password
+)
 
-let connPropertiesStr = connProperties.toString()
-Log.info("connPropertiesStr:\n\(connPropertiesStr)")
+Log.info("Connection Properties:\n\(connProperties)")
 
 // Create couchDBClient instance using conn properties
 let couchDBClient = CouchDBClient(connectionProperties: connProperties)
-Log.info("Hostname is: \(couchDBClient.connProperties.hostName)")
+Log.info("Hostname is: \(couchDBClient.connProperties.host)")
 
 // Create database instance to perform any document operations
 let database = couchDBClient.database("kitura_test_db")
@@ -61,89 +61,94 @@ let database = couchDBClient.database("kitura_test_db")
 let documentId = "123456"
 
 // JSON document in string format
-let jsonStr =
-  "{" +
-    "\"_id\": \"\(documentId)\"," +
-    "\"coordinates\": null," +
-    "\"truncated\": false," +
-    "\"created_at\": \"Tue Aug 28 21:16:23 +0000 2012\"," +
-    "\"favorited\": false," +
-    "\"value\": \"value1\"" +
-  "}"
+let json: JSON = [
+    "_id": documentId,
+    "truncated": false,
+    "created_at": "Tue Aug 28 21:16:23 +0000 2012",
+    "favorited": false,
+    "value": "value1",
+]
 
-// Convert JSON string to NSData
-let jsonData = jsonStr.bridge().dataUsingEncoding(NSUTF8StringEncoding)
-// Convert NSData to JSON object
-let json = JSON(data: jsonData!)
+
+// MARK: Chainer
 
 func chainer(document: JSON?, next: (revisionNumber: String) -> Void) {
-  if let revisionNumber = document?["rev"].string {
-    Log.info("revisionNumber is \(revisionNumber)")
-    next(revisionNumber: revisionNumber)
-  } else if let revisionNumber = document?["_rev"].string {
-    Log.info("revisionNumber is \(revisionNumber)")
-    next(revisionNumber: revisionNumber)
-  } else {
-    Log.error(">> Oops something went wrong... could not get revisionNumber!")
-  }
-}
-
-//Delete document
-func deleteDocument(revisionNumber: String) {
-  database.delete(documentId, rev: revisionNumber, failOnNotFound: false,
-    callback: { (error: NSError?) in
-        if let error = error {
-            Log.error(">> Oops something went wrong; could not delete document.")
-            Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
-        } else {
-            Log.info(">> Successfully deleted the JSON document with ID \(documentId) from CouchDB.")
-        }
-  })
-}
-
-//Update document
-func updateDocument(revisionNumber: String) {
-  //var json = JSON(data: jsonData!)
-  //json["value"] = "value2"
-  database.update(documentId, rev: revisionNumber, document: json,
-    callback: { (rev: String?, document: JSON?, error: NSError?) in
-        if let error = error {
-            Log.error(">> Oops something went wrong; could not update document.")
-            Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
-        } else {
-            Log.info(">> Successfully updated the JSON document with ID" +
-                "\(documentId) in CouchDB:\n\t\(document)")
-            chainer(document, next: deleteDocument)
-        }
-  })
-}
-
-//Read document
-func readDocument() {
-  database.retrieve(documentId, callback: { (document: JSON?, error: NSError?) in
-    if let error = error {
-      Log.error("Oops something went wrong; could not read document.")
-      Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
+    if let revisionNumber = document?["rev"].string {
+        Log.info("revisionNumber is \(revisionNumber)")
+        next(revisionNumber: revisionNumber)
+    } else if let revisionNumber = document?["_rev"].string {
+        Log.info("revisionNumber is \(revisionNumber)")
+        next(revisionNumber: revisionNumber)
     } else {
-      Log.info(">> Successfully read the following JSON document with ID " +
-            "\(documentId) from CouchDB:\n\t\(document)")
-      chainer(document, next: updateDocument)
+        Log.error(">> Oops something went wrong... could not get revisionNumber!")
     }
-  })
 }
 
-//Create document closure
+
+// MARK: Create document
+
 func createDocument() {
-  database.create(json, callback: { (id: String?, rev: String?, document: JSON?, error: NSError?) in
-    if let error = error {
-      Log.error(">> Oops something went wrong; could not persist document.")
-      Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
-    } else {
-      Log.info(">> Successfully created the following JSON document in CouchDB:\n\t\(document)")
-      readDocument()
-    }
-  })
+    database.create(json, callback: { (id: String?, rev: String?, document: JSON?, error: NSError?) in
+        if let error = error {
+            Log.error(">> Oops something went wrong; could not persist document.")
+            Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
+        } else {
+            Log.info(">> Successfully created the following JSON document in CouchDB:\n\t\(document)")
+            readDocument()
+        }
+    })
 }
+
+
+// MARK: Read document
+
+func readDocument() {
+    database.retrieve(documentId, callback: { (document: JSON?, error: NSError?) in
+        if let error = error {
+            Log.error("Oops something went wrong; could not read document.")
+            Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
+        } else {
+            Log.info(">> Successfully read the following JSON document with ID " +
+                "\(documentId) from CouchDB:\n\t\(document)")
+            chainer(document, next: updateDocument)
+        }
+    })
+}
+
+
+// MARK: Update document
+
+func updateDocument(revisionNumber: String) {
+    //var json = JSON(data: jsonData!)
+    //json["value"] = "value2"
+    database.update(documentId, rev: revisionNumber, document: json,
+        callback: { (rev: String?, document: JSON?, error: NSError?) in
+            if let error = error {
+                Log.error(">> Oops something went wrong; could not update document.")
+                Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
+            } else {
+                Log.info(">> Successfully updated the JSON document with ID" +
+                    "\(documentId) in CouchDB:\n\t\(document)")
+                chainer(document, next: deleteDocument)
+            }
+    })
+}
+
+
+// MARK: Delete document
+
+func deleteDocument(revisionNumber: String) {
+    database.delete(documentId, rev: revisionNumber, failOnNotFound: false,
+        callback: { (error: NSError?) in
+            if let error = error {
+                Log.error(">> Oops something went wrong; could not delete document.")
+                Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
+            } else {
+                Log.info(">> Successfully deleted the JSON document with ID \(documentId) from CouchDB.")
+            }
+    })
+}
+
 
 // Start tests...
 createDocument()

--- a/Sources/CouchDBSample/main.swift
+++ b/Sources/CouchDBSample/main.swift
@@ -29,23 +29,13 @@ import HeliumLogger
 Log.logger = HeliumLogger()
 Log.info("Starting sample program...")
 
-// Parse runtime args... this is just an interim solution
-let args = Array(Process.arguments[1..<Process.arguments.count])
-if args.count != 3 {
-    Log.error("Hostname, username and password are required as arguments!")
-    exit(1)
-}
-let host = args[0]
-let username = args[1]
-let password = args[2]
-
 // Connection properties for testing Cloudant or CouchDB instance
 let connProperties = ConnectionProperties(
-    host: host,
-    port: 5984,
-    secured: false,
-    username: username,
-    password: password
+    host: "127.0.0.1",  // httpd address
+    port: 5984,         // httpd port
+    secured: false,     // https or http
+    username: nil,      // admin username
+    password: nil       // admin password
 )
 
 Log.info("Connection Properties:\n\(connProperties)")


### PR DESCRIPTION
- CouchDBSample's **main.swift** now creates a connection on port **5984**, the default port used by CouchDB upon install.
- Changed the name of the default database which Kitura tries to connect to: `kitura_test_db`. The README.md is also updated to mention that a database with this name needs to be created.
- The README.md has updated and more thorough installation instructions.
- Improved error logging with HeliumLogger.
