### PR TITLE
Query parameters case keys fix #8

### DIFF
--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -36,11 +36,7 @@ public class Database {
     public enum QueryParameters {
         case Conflicts (Bool)
         case Descending (Bool)
-        #if os(Linux)
-        case EndKey ([Any])
-        #else
-        case EndKey ([AnyObject])
-        #endif
+        case EndKey (Any)
         case EndKeyDocID (String)
         case Group (Bool)
         case GroupLevel (Int)
@@ -52,11 +48,7 @@ public class Database {
         case Reduce (Bool)
         case Skip (Int)
         case Stale (StaleOptions)
-        #if os(Linux)
-        case StartKey ([Any])
-        #else
-        case StartKey ([AnyObject])
-        #endif
+        case StartKey (Any)
         case StartKeyDocID (String)
         case UpdateSequence (Bool)
         #if os(Linux)

--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -36,7 +36,11 @@ public class Database {
     public enum QueryParameters {
         case Conflicts (Bool)
         case Descending (Bool)
-        case EndKey (AnyObject)
+        #if os(Linux)
+        case EndKey ([Any])
+        #else
+        case EndKey ([AnyObject])
+        #endif
         case EndKeyDocID (String)
         case Group (Bool)
         case GroupLevel (Int)
@@ -48,10 +52,18 @@ public class Database {
         case Reduce (Bool)
         case Skip (Int)
         case Stale (StaleOptions)
-        case StartKey (AnyObject)
+        #if os(Linux)
+        case StartKey ([Any])
+        #else
+        case StartKey ([AnyObject])
+        #endif
         case StartKeyDocID (String)
         case UpdateSequence (Bool)
+        #if os(Linux)
+        case Keys ([Any])
+        #else
         case Keys ([AnyObject])
+        #endif
     }
 
     public static let Error = [
@@ -68,7 +80,7 @@ public class Database {
     public let escapedName: String
     public let connProperties: ConnectionProperties
 
-    private static func createQueryParamForArray(array: Array<AnyObject>) -> String {
+    private static func createQueryParamForArray(array: [Any]) -> String {
         var result = "["
         var comma = ""
         for element in array {
@@ -214,7 +226,12 @@ public class Database {
 
     public func queryByView(view: String, ofDesign design: String, usingParameters params: [Database.QueryParameters], callback: (JSON?, NSError?) -> ()) {
         var paramString = ""
-        var keys: [AnyObject]?
+
+        #if os(Linux)
+            var keys: [Any]?
+        #else
+            var keys: [AnyObject]?
+        #endif
 
         for param in params {
             switch param {
@@ -225,8 +242,8 @@ public class Database {
             case .EndKey (let value):
                 if let value = value as? String {
                     paramString += "endkey=\"\(Http.escapeUrl(value))\"&"
-                } else if value is Array<AnyObject> {
-                    paramString += "endkey=" + Database.createQueryParamForArray(value as! Array<AnyObject>) + "&"
+                } else if value is [Any] {
+                    paramString += "endkey=" + Database.createQueryParamForArray(value as! [Any]) + "&"
                 }
             case .EndKeyDocID (let value):
                 paramString += "endkey_docid=\"\(Http.escapeUrl(value))\"&"
@@ -253,8 +270,8 @@ public class Database {
             case .StartKey (let value):
                 if value is String {
                     paramString += "startkey=\"\(Http.escapeUrl(value as! String))\"&"
-                } else if value is Array<AnyObject> {
-                    paramString += "startkey=" + Database.createQueryParamForArray(value as! Array<AnyObject>) + "&"
+                } else if value is [Any] {
+                    paramString += "startkey=" + Database.createQueryParamForArray(value as! [Any]) + "&"
                 }
             case .StartKeyDocID (let value):
                 paramString += "start_key_doc_id=\"\(Http.escapeUrl(value))\"&"
@@ -264,8 +281,8 @@ public class Database {
                 if value.count == 1 {
                     if value[0] is String {
                         paramString += "key=\"\(Http.escapeUrl(value[0] as! String))\"&"
-                    } else if value[0] is Array<AnyObject> {
-                        paramString += "key=" + Database.createQueryParamForArray(value[0] as! Array<AnyObject>) + "&"
+                    } else if value[0] is [Any] {
+                        paramString += "key=" + Database.createQueryParamForArray(value[0] as! [Any]) + "&"
                     }
                 } else {
                     keys = value

--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -51,7 +51,11 @@ public class Database {
         case StartKey ([AnyObject])
         case StartKeyDocID (String)
         case UpdateSequence (Bool)
+        #if os(Linux)
+        case Keys ([Any])
+        #else
         case Keys ([AnyObject])
+        #endif
     }
 
     public static let Error = [

--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -72,7 +72,7 @@ public class Database {
     public let escapedName: String
     public let connProperties: ConnectionProperties
 
-    private static func createQueryParamForArray(array: [Any]) -> String {
+    private static func createQueryParamForArray(_ array: [Any]) -> String {
         var result = "["
         var comma = ""
         for element in array {

--- a/Tests/CouchDB/DocumentViewTests.swift
+++ b/Tests/CouchDB/DocumentViewTests.swift
@@ -1,0 +1,186 @@
+/**
+* Copyright IBM Corporation 2016
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import XCTest
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin
+#endif
+
+import Foundation
+import SwiftyJSON
+
+@testable import CouchDB
+
+class DocumentViewTests : XCTestCase {
+
+    static var allTests : [(String, DocumentCrudTests -> () throws -> Void)] {
+        return [
+            ("testViewTest", testViewTest)
+        ]
+    }
+
+    var database: Database?
+    let documentId = "123456"
+    var jsonDocument: JSON?
+    let dbName = "kitura_db"
+
+    func testCrudTest() {
+        let credentials = Utils.readCredentials()
+
+        // Connection properties for testing Cloudant or CouchDB instance
+        let connProperties = ConnectionProperties(host: credentials.host,
+            port: credentials.port, secured: false,
+            username: credentials.username,
+            password: credentials.password)
+
+        // Create couchDBClient instance using conn properties
+        let couchDBClient = CouchDBClient(connectionProperties: connProperties)
+        print("Hostname is: \(couchDBClient.connProperties.host)")
+
+        // Check if DB exists
+        couchDBClient.dbExists(dbName) {exists, error in
+            if let error = error  {
+                XCTFail("Failed checking existence of database \(self.dbName)")
+            }
+            else {
+                if  exists  {
+                    // Create database handle to perform any document operations
+                    self.database = couchDBClient.database(self.dbName)
+
+                    // Start tests...
+                    self.createDocument()
+                }
+                else {
+                    // Create database
+                    couchDBClient.createDB(self.dbName) {db, error in
+                        if  error != nil  {
+                            XCTFail("Failed creating the database \(self.dbName)")
+                        }
+                        else {
+                            self.database = db
+
+                            // Start tests...
+                            self.createDocument()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func chainer(_ document: JSON?, next: (revisionNumber: String) -> Void) {
+        if let revisionNumber = document?["rev"].string {
+            print("revisionNumber is \(revisionNumber)")
+            next(revisionNumber: revisionNumber)
+        }
+        else if let revisionNumber = document?["_rev"].string {
+            print("revisionNumber is \(revisionNumber)")
+            next(revisionNumber: revisionNumber)
+        }
+        else {
+            XCTFail(">> Oops something went wrong... could not get revisionNumber!")
+        }
+    }
+
+    //Delete document
+    func deleteDocument(_ revisionNumber: String) {
+        database!.delete(documentId, rev: revisionNumber, failOnNotFound: true, callback: { (error: NSError?) in
+            if let error = error {
+                XCTFail("Error in rereading document \(error.code) \(error.domain) \(error.userInfo)")
+            }
+            else {
+                print(">> Successfully deleted the JSON document with ID \(self.documentId) from CouchDB.")
+            }
+        })
+    }
+
+    //Read document
+    func readDocument() {
+        let key = "viewTest"
+        database!.queryByView("matching", design: "test", params: [.Keys([key])]) { (document: JSON?, error: NSError?) in
+            if let error = error {
+                XCTFail("Error in querying by view document \(error.code) \(error.domain) \(error.userInfo)")
+            } else {
+                guard let row = document["rows"].first as JSON!, id = row["_id"].string, value = row["value"].string else {
+                        XCTFail("Error: Keys not found when reading document")
+                        exit(1)
+                }
+                
+                XCTAssertEqual(self.documentId, id, "Wrong documentId read from document")
+                XCTAssertEqual(key, value, "Wrong value read from document")
+                
+                print(">> Successfully read the following JSON document: ")
+                print(document)
+            }
+        }
+    }
+
+    //Create document closure
+    func createDocument() {
+        // JSON document in string format
+        let jsonStr =
+        "{" +
+            "\"_id\": \"\(documentId)\"," +
+            "\"coordinates\": null," +
+            "\"truncated\": false," +
+            "\"created_at\": \"Tue Aug 28 21:16:23 +0000 2012\"," +
+            "\"favorited\": false," +
+            "\"value\": \"viewTest\"" +
+        "}"
+
+        // Convert JSON string to NSData
+        #if os(Linux)
+        let jsonData = jsonStr.bridge().dataUsingEncoding(NSUTF8StringEncoding)
+        #else
+        let jsonData = jsonStr.bridge().data(using: NSUTF8StringEncoding)
+        #endif
+        // Convert NSData to JSON object
+        jsonDocument = JSON(data: jsonData!)
+        database!.create(jsonDocument!, callback: { (id: String?, rev: String?, document: JSON?, error: NSError?) in
+            if let error = error {
+                XCTFail("Error in creating document \(error.code) \(error.domain) \(error.userInfo)")
+            }
+            else {
+                print(">> Successfully created the JSON document.")
+                self.createDesign()
+            }
+        })
+    }
+    
+    func createDesign() {
+        let name = "test"
+        let designDocument = JSON(["_id" : "_design/\(name)",
+            "views" : [
+                "matching" : [
+                    "map" : "function(doc) { emit(doc.value, doc); }"
+                ]
+            ]
+            ])
+
+        database!.createDesign(name, document: designDocument) { (document: JSON?, error: NSError?) in
+            if let error = error {
+                XCTFail("Error in creating document \(error.code) \(error.domain) \(error.userInfo)")
+            }
+            else {
+                print(">> Successfully created the design.")
+                self.readDocument()
+            }
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -20,5 +20,6 @@ import XCTest
 
 XCTMain([
     testCase(DocumentCrudTests.allTests),
-    testCase(DBTests.allTests)
+    testCase(DBTests.allTests),
+    testable(DocumentViewTests.allTests)
 ])


### PR DESCRIPTION
## Description

Update Database.swift to work when querying by views and using the .Key parameters. 
- Changed the StartKey/EndKey to `Any` type.
- Changed the Keys to `[Any]`
- Changed the types from `Array<Any>` to `[Any]`
## Motivation and Context

Reference to issue #8 
## How Has This Been Tested?

Tested manually on both OS X and Ubuntu with the 04/25 drop of Swift. I have added a test.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
