### PR TITLE
Allow for a key to be an integer and fix Any/AnyObject KeyType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build/
 Packages/
+Kitura-CouchDB.xcodeproj/

--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -229,11 +229,7 @@ public class Database {
     
     public func queryByView(_ view: String, ofDesign design: String, usingParameters params: [Database.QueryParameters], callback: (JSON?, NSError?) -> ()) {
         var paramString = ""
-        #if os(Linux)
-            var keys: [Any]?
-        #else
-            var keys: [AnyObject]?
-        #endif
+        var keys: [KeyType]?
         
         for param in params {
             switch param {
@@ -291,7 +287,7 @@ public class Database {
                 if value.count == 1 {
                     if value[0] is String {
                         paramString += "key=\"\(HTTP.escapeUrl(value[0] as! String))\"&"
-                    } else if value[0] is [Any] {
+                    } else if value[0] is [KeyType] {
                         paramString += "key=" + Database.createQueryParamForArray(value[0] as! [KeyType]) + "&"
                     }
                 } else {

--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -291,6 +291,8 @@ public class Database {
                 if value.count == 1 {
                     if value[0] is String {
                         paramString += "key=\"\(HTTP.escapeUrl(value[0] as! String))\"&"
+                    } else if value[0] is Int {
+                        paramString += "key=\(value[0])&"
                     } else if value[0] is [Any] {
                         paramString += "key=" + Database.createQueryParamForArray(value[0] as! [KeyType]) + "&"
                     }


### PR DESCRIPTION
## Description

Previously something like this:
`database.queryByView("by-class", ofDesign: "category", usingParameters: [.limit(1), .keys([classId])])`

Would not work if `classId` was of type Int. This change adds another if/else to check for keys that could be an integer.

In the same if/else check as above, a check was being made for `[Any]`. This has been updated to be use the previously defined `[KeyType]`. `KeyType` is used in other places and correctly sets the type to either `Any` or `AnyObject` depending if it's either Linux or OS X.

I'm also excluding the Xcode generated project dir in .the `.gitignore` that gets generated when built with `swift build -X`.
## Motivation and Context

This is required in order to pass integer keys to CouchDB and also to catch other key types correctly on both OS X and Linux.
## How Has This Been Tested?

This has been tested on both Mac OS X and Linux.
## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
