### PR TITLE
Fix for IBM-Swift/Kitura#576 

### DIFF
--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -229,11 +229,7 @@ public class Database {
     
     public func queryByView(_ view: String, ofDesign design: String, usingParameters params: [Database.QueryParameters], callback: (JSON?, NSError?) -> ()) {
         var paramString = ""
-        #if os(Linux)
-            var keys: [Any]?
-        #else
-            var keys: [AnyObject]?
-        #endif
+        var keys: [KeyType]?
         
         for param in params {
             switch param {
@@ -291,7 +287,7 @@ public class Database {
                 if value.count == 1 {
                     if value[0] is String {
                         paramString += "key=\"\(HTTP.escape(url: value[0] as! String))\"&"
-                    } else if value[0] is [Any] {
+                    } else if value[0] is [KeyType] {
                         paramString += "key=" + Database.createQueryParamForArray(value[0] as! [KeyType]) + "&"
                     }
                 } else {


### PR DESCRIPTION
Queries that fetched a set of keys weren't handling the array of keys correctly
## Description

Changed [Any] to [KeyType] in code parsing keys in query. Also used KeyType to eliminate platform specific types.
## Motivation and Context

Fixes issue IBM-Swift/Kitura#576 
## How Has This Been Tested?

Recreated the bug as in the comments of issue IBM-Swift/Kitura#576. Ran the test program on both Linux and OSX.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
