### PR TITLE
IBM-Swift/Kitura-CouchDB#21 Implement retrieveAll

### DIFF
--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -134,6 +134,37 @@ public class Database {
     }
     
     ///
+    /// Retrieve all documents from the database
+    ///
+    /// - Parameter includeDocuments: A boolean value that indicates whether to include the full content 
+    ///                               of the documents. Default is false.
+    /// - Parameter callback: callback function with the document's JSON
+    ///
+    public func retrieveAll(includeDocuments: Bool = false, callback: (JSON?, NSError?) -> ()) {
+        
+        var path = "/\(escapedName)/_all_docs"
+        if includeDocuments {
+            path += "?include_docs=true"
+        }
+        let requestOptions = CouchDBUtils.prepareRequest(connProperties, method: "GET",
+                                                         path: path, hasBody: false)
+        var document: JSON?
+        let req = HTTP.request(requestOptions) { response in
+            var error: NSError?
+            if let response = response {
+                document = CouchDBUtils.getBodyAsJson(response)
+                if response.statusCode != HTTPStatusCode.OK {
+                    error = CouchDBUtils.createError(response.statusCode, errorDesc: document, id: nil, rev: nil)
+                }
+            } else {
+                error = CouchDBUtils.createError(Database.InternalError, id: nil, rev: nil)
+            }
+            callback(document, error)
+        }
+        req.end()
+    }
+    
+    ///
     /// Update a document in the database
     ///
     /// - Parameter id: String ID for the document


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implement retrieveAll API
## Description

<!--- Describe your changes in detail -->

Implemented retrieveAll API that allows to retrieve all the documents in the database with or without their full content (controlled by includeDocuments argument)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

https://github.com/IBM-Swift/Kitura-CouchDB/issues/21

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

Tested on OSX and Linux. Added a test for this API.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
