### PR TITLE
Refactored parameter sent to Package-Builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
 before_install:
   - git submodule update --init --remote --merge --recursive
   - git clone -b master "https://$GITHUB_USER:$GITHUB_PWD@github.com/IBM-Swift/Kitura-TestingCredentials.git"
+  - cd Package-Builder
+  - git checkout testing_repo
+  - cd ..
 
 script:
-  - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura-TestingCredentials
+  - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/Kitura-TestingCredentials/Kitura-CouchDB

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_install:
   - git clone -b master "https://$GITHUB_USER:$GITHUB_PWD@github.com/IBM-Swift/Kitura-TestingCredentials.git"
 
 script:
-  - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR
+  - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura-TestingCredentials

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
 before_install:
   - git submodule update --init --remote --merge --recursive
   - git clone -b master "https://$GITHUB_USER:$GITHUB_PWD@github.com/IBM-Swift/Kitura-TestingCredentials.git"
-  - cd Package-Builder
-  - git checkout testing_repo
-  - cd ..
 
 script:
   - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/Kitura-TestingCredentials/Kitura-CouchDB


### PR DESCRIPTION
We simplified some code in package builder which required the parameter sent to it be the directory where its at instead of the just the name
