### PR TITLE
getUUID/getUUIDs from the /_uuids API

### DIFF
--- a/Sources/CouchDB/CouchDBClient.swift
+++ b/Sources/CouchDB/CouchDBClient.swift
@@ -160,10 +160,10 @@ public class CouchDBClient {
 
     public func getUUIDs(count : UInt, callback : @escaping ([String]?, NSError?) -> Void) {
 
-        let url = "_uuids?count=\(count)"
+        let url = "/_uuids?count=\(count)"
 
         let requestOptions = CouchDBUtils.prepareRequest(connProperties, method: "GET",
-                                                         path: "/\(url)", hasBody: false)
+                                                         path: url, hasBody: false)
         let req = HTTP.request(requestOptions) { response in
             var error: NSError?
             var uuids: [String]?

--- a/Tests/CouchDBTests/UUIDTests.swift
+++ b/Tests/CouchDBTests/UUIDTests.swift
@@ -1,0 +1,99 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin
+#endif
+
+import Foundation
+import SwiftyJSON
+
+@testable import CouchDB
+
+class UUIDTests : XCTestCase {
+
+    static var allTests: [(String, (UUIDTests) -> () throws -> Void)] {
+        return [
+            ("testUUIDsTest", testUUIDsTest),
+            ("testUUIDTest", testUUIDTest),
+        ]
+    }
+
+    func testUUIDsTest() {
+        let credentials = Utils.readCredentials()
+
+        // Connection properties for testing Cloudant or CouchDB instance
+        let connProperties = ConnectionProperties(host: credentials.host,
+                                                  port: credentials.port, secured: false,
+                                                  username: credentials.username,
+                                                  password: credentials.password)
+
+        // Create couchDBClient instance using conn properties
+        let couchDBClient = CouchDBClient(connectionProperties: connProperties)
+
+        print("Hostname is: \(couchDBClient.connProperties.host)")
+
+        let expectedCount : UInt = 10
+        couchDBClient.getUUIDs(count: expectedCount) { (uuids, error) in
+
+            if error != nil {
+                XCTFail("Failed to retrieve \(expectedCount) UUIDs: \(error)")
+            } else {
+                if let uuids = uuids {
+
+                    XCTAssertEqual(uuids.count, Int(expectedCount), "Expected count of UUIDs to be \(expectedCount), instead it is \(uuids.count)")
+                    print(">> Successfully retrieved \(expectedCount) UUIDs")
+                } else {
+                    XCTFail("Failed to retrieve \(expectedCount) UUIDs, nil retrieved")
+                }
+            }
+        }
+    }
+
+    func testUUIDTest() {
+        let credentials = Utils.readCredentials()
+
+        // Connection properties for testing Cloudant or CouchDB instance
+        let connProperties = ConnectionProperties(host: credentials.host,
+                                                  port: credentials.port, secured: false,
+                                                  username: credentials.username,
+                                                  password: credentials.password)
+
+        // Create couchDBClient instance using conn properties
+        let couchDBClient = CouchDBClient(connectionProperties: connProperties)
+
+        print("Hostname is: \(couchDBClient.connProperties.host)")
+
+        couchDBClient.getUUID() { (uuid, error) in
+
+            if error != nil {
+                XCTFail("Failed to retrieve a UUID: \(error)")
+            } else {
+                if uuid != nil {
+
+                    print(">> Successfully retrieved a UUID")
+                } else {
+                    XCTFail("Failed to retrieve a UUID, nil retrieved")
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Description

These changes add a way to request a UUID through `CouchDBClient.getUUID` or multiple UUIDs through `CouchDBClient.getUUIDs`, both from the `/_uuids` endpoint (more information [here](http://docs.couchdb.org/en/2.0.0/api/server/common.html#uuids)
## Motivation and Context

CouchDB provides a method to generate UUIDs for use in common methods such as creating a new document. These changes provide access to that generator.
## How Has This Been Tested?

These changes include two test functions, one for `getUUID`, one for `getUUIDs`. Each test does basic verification of the results after calling their appropriate function.
## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- **not applicable** If applicable, I have updated the documentation accordingly. 
- [x] If applicable, I have added tests to cover my changes.
