### PR TITLE
Refactored testing credentials again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_install:
   - git clone -b master "https://$GITHUB_USER:$GITHUB_PWD@github.com/IBM-Swift/Kitura-TestingCredentials.git"
 
 script:
-  - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura-TestingCredentials
+  - ./Package-Builder/build-package.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/Kitura-TestingCredentials/Kitura-CouchDB


### PR DESCRIPTION
Refactored the code to where instead of just passing in the Credentials repo directory name you actually pass in the the directory of where the credentials repo item is.  For instance before you would just pass in:

Kitura-TestingCredentials

now you pass in the directory of the item in the credentials repo that you want to use:

$TRAVIS_BUILD_DIR/Kitura-TestingCredentials/Kitura-CouchDB

This was done to support multiple credentials repos that used multiple test directories.
