### PR TITLE
Make sure database names are different in macOS and Linux tests

### DIFF
--- a/Tests/CouchDBTests/DBTests.swift
+++ b/Tests/CouchDBTests/DBTests.swift
@@ -34,6 +34,13 @@ class DBTests: XCTestCase {
         ("testDB", testDB),
     ]
   }
+    
+  // To enable running Linux and OSX tests in parallel
+  #if os(Linux)
+    let dbName = "test_db_linux"
+  #else
+    let dbName = "test_db_db"
+  #endif
 
   func testDB() {
     let credentials = Utils.readCredentials()
@@ -48,7 +55,7 @@ class DBTests: XCTestCase {
     let couchDBClient = CouchDBClient(connectionProperties: connProperties)
     print("Hostname is: \(couchDBClient.connProperties.host)")
 
-    couchDBClient.createDB("test_db") {(db: Database?, error: NSError?) in
+    couchDBClient.createDB(dbName) {(db: Database?, error: NSError?) in
         if let error = error {
             XCTFail("DB creation error: \(error.code) \(error.localizedDescription)")
         }


### PR DESCRIPTION
A pair of tests will fail if unfortunately they run at the same time on both Linux and macOS in our Travis-CI setup. This test of create and delete a database must use different database names for macOS and Linux, as do our other CouchDB tests.

## Description
Insure that the DBTests use a separate Database name for macOS and Liux tests.

## Motivation and Context
Build failures reported in IBM-swift/Kitura#921 

## How Has This Been Tested?
Ran Kitura-CouchDB unit tests almost at the same time on both macOS and Linux against the same couchdb server.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.