### PR TITLE
Fix problems running code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       sudo: required
 
 before_install:
-  - git clone https://github.com/shmuelk/Package-Builder.git
+  - git clone https://github.com/IBM-Swift/Package-Builder.git
   - git clone -b master "https://$GITHUB_USER:$GITHUB_PWD@github.com/IBM-Swift/Kitura-TestingCredentials.git"
 
 script:

--- a/Tests/CouchDBTests/Utils.swift
+++ b/Tests/CouchDBTests/Utils.swift
@@ -43,8 +43,17 @@ class Utils {
     static func readCredentials() -> Credentials {
         // Read in credentials an Data
         let credentialsData: Data
+        let sourceFileName = NSString(string: #file)
+        let resourceFilePrefixRange: NSRange
+        let lastSlash = sourceFileName.range(of: "/", options: .backwards)
+        if  lastSlash.location != NSNotFound {
+            resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
+        } else {
+            resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
+        }
+        let fileNamePrefix = sourceFileName.substring(with: resourceFilePrefixRange)
         do {
-            credentialsData = try Data(contentsOf: URL(fileURLWithPath: "Tests/CouchDBTests/credentials.json"))
+            credentialsData = try Data(contentsOf: URL(fileURLWithPath: "\(fileNamePrefix)credentials.json"))
         } catch {
             XCTFail("Failed to read in the credentials.json file")
             exit(1)


### PR DESCRIPTION
## Description
The code coverage portion of the build fails for Kitra-CouchDB due to its reading in of files to be used during the  test in a way that is relative to the repository. This works when running swift test, but fails when running from within XCode. 

## Motivation and Context
Enable code coverage for Kitura-CouchDB

## How Has This Been Tested?
Ran Kitura-CouchDB unit tests both from swift test and XCode.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
