### PR TITLE
Fix String interpolation warnings for 3.1

### DIFF
--- a/Sources/CouchDB/ConnectionProperties.swift
+++ b/Sources/CouchDB/ConnectionProperties.swift
@@ -78,8 +78,8 @@ extension ConnectionProperties: CustomStringConvertible {
         return  "\thost -> \(host)\n" +
             "\tport -> \(port)\n" +
             "\tsecured -> \(secured)\n" +
-            "\tusername -> \(username)\n" +
-            "\tpassword -> \(password)\n" +
+            "\tusername -> \(String(describing: username))\n" +
+            "\tpassword -> \(String(describing: password))\n" +
             "\tURL -> \(URL)"
     }
 }

--- a/Sources/CouchDBSample/main.swift
+++ b/Sources/CouchDBSample/main.swift
@@ -123,7 +123,7 @@ func createDocument() {
             Log.error(">> Oops something went wrong; could not persist document.")
             Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
         } else {
-            Log.info(">> Successfully created the following JSON document in CouchDB:\n\t\(document)")
+            Log.info(">> Successfully created the following JSON document in CouchDB:\n\t\(String(describing: document))")
             readDocument()
         }
     })
@@ -139,7 +139,7 @@ func readDocument() {
             Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
         } else {
             Log.info(">> Successfully read the following JSON document with ID " +
-                "\(documentId) from CouchDB:\n\t\(document)")
+                "\(documentId) from CouchDB:\n\t\(String(describing: document))")
             chainer(document, next: updateDocument)
         }
     })
@@ -158,7 +158,7 @@ func updateDocument(revisionNumber: String) {
                 Log.error("Error: \(error.localizedDescription) Code: \(error.code)")
             } else {
                 Log.info(">> Successfully updated the JSON document with ID" +
-                    "\(documentId) in CouchDB:\n\t\(document)")
+                    "\(documentId) in CouchDB:\n\t\(String(describing: document))")
                 chainer(document, next: deleteDocument)
             }
     })

--- a/Tests/CouchDBTests/UUIDTests.swift
+++ b/Tests/CouchDBTests/UUIDTests.swift
@@ -54,7 +54,7 @@ class UUIDTests : XCTestCase {
         couchDBClient.getUUIDs(count: expectedCount) { (uuids, error) in
 
             if error != nil {
-                XCTFail("Failed to retrieve \(expectedCount) UUIDs: \(error)")
+                XCTFail("Failed to retrieve \(expectedCount) UUIDs: \(String(describing: error))")
             } else {
                 if let uuids = uuids {
 
@@ -84,7 +84,7 @@ class UUIDTests : XCTestCase {
         couchDBClient.getUUID() { (uuid, error) in
 
             if error != nil {
-                XCTFail("Failed to retrieve a UUID: \(error)")
+                XCTFail("Failed to retrieve a UUID: \(String(describing: error))")
             } else {
                 if uuid != nil {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix String interpolation warnings for 3.1

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
