### PR TITLE
Implement workaround to make code coverage work

### DIFF
--- a/Sources/CouchDBSample/main.swift
+++ b/Sources/CouchDBSample/main.swift
@@ -48,11 +48,43 @@ if args.count == 1  &&  args[0] == "--help" {
     exit(0)
 }
 
-let host = args.count > 0 ? args[0] : "127.0.0.1" /* localhost */
-let port = args.count > 1 ? Int16(args[1]) ?? 5984 : 5984
-let secured = args.count > 2 ? (args[2].lowercased() == "secure") : false
-let username: String? = args.count == 5 ? args[3] : nil
-let password: String? = args.count == 5 ? args[4] : nil
+// The following assignments for now can't be collapsed to simple statements with a tertiary (?:)
+// operator due to the bug in XCode 8.3 code coverage reported here https://bugs.swift.org/browse/SR-4453
+
+let host: String
+if args.count > 0 {
+    host = args[0]
+}
+else {
+    host = "127.0.0.1" /* localhost */
+}
+
+let port: Int16
+if args.count > 1 {
+    port = Int16(args[1]) ?? 5984
+}
+else {
+    port = 5984
+}
+
+let secured: Bool
+if args.count > 2 {
+    secured = (args[2].lowercased() == "secure")
+}
+else {
+    secured = false
+}
+
+let username: String?
+let password: String? 
+if args.count == 5 {
+    username = args[3]
+    password = args[4]
+}
+else {
+    username = nil
+    password = nil
+}
 
 // Connection properties for testing Cloudant or CouchDB instance
 let connProperties = ConnectionProperties(


### PR DESCRIPTION
## Description
There is a bug in XCode 8.3 code coverage in which tertiary (?:) operators in top level code cause a SIGSEGV. This bug has been reported here https://bugs.swift.org/browse/SR-4453.

Until that bug is fixed in a public version of XCode, we need to use if statements to conditionally assign the values in the beginning of Kitura-CouchDB/Sources/CouchDBSample/main.swift

## Motivation and Context
Fix code coverage breakage.

## How Has This Been Tested?
Ran code coverage locally without the fix and then with the fix. Without the fix, running code coverage results in a SIGSEGV. With the fix code coverage runs to completion.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
