### PR TITLE
Remove `catch let err as NSError` on Linux (regardless of Swift version) to prevent runtime cra…

### DIFF
--- a/Sources/CouchDB/CouchDBClient.swift
+++ b/Sources/CouchDB/CouchDBClient.swift
@@ -171,7 +171,7 @@ public class CouchDBClient {
                 if response.statusCode == HTTPStatusCode.OK {
 
                     var data = Data()
-#if os(Linux) && swift(>=3.1)
+#if os(Linux)
                     do {
                         try response.readAllData(into: &data)
 
@@ -184,7 +184,7 @@ public class CouchDBClient {
                         })
 
                     } catch let caughtError {
-                        error = caughtError as? NSError ?? NSError(domain: caughtError.localizedDescription, code: -1)
+                        error = NSError(domain: caughtError.localizedDescription, code: -1)
                     }
 #else
                     do {

--- a/Sources/CouchDB/CouchDBClient.swift
+++ b/Sources/CouchDB/CouchDBClient.swift
@@ -171,7 +171,6 @@ public class CouchDBClient {
                 if response.statusCode == HTTPStatusCode.OK {
 
                     var data = Data()
-#if os(Linux)
                     do {
                         try response.readAllData(into: &data)
 
@@ -182,26 +181,13 @@ public class CouchDBClient {
                         uuids = uuidsJSON.array?.flatMap({ (uuidJSON) -> String? in
                             return uuidJSON.string
                         })
-
                     } catch let caughtError {
+                        #if os(Linux)
                         error = NSError(domain: caughtError.localizedDescription, code: -1)
+                        #else
+                        error = caughtError as NSError
+                        #endif
                     }
-#else
-                    do {
-                        try response.readAllData(into: &data)
-
-                        let responseJSON = JSON(data: data)
-
-                        let uuidsJSON = responseJSON["uuids"]
-
-                        uuids = uuidsJSON.array?.flatMap({ (uuidJSON) -> String? in
-                            return uuidJSON.string
-                        })
-
-                    } catch let caughtError as NSError {
-                        error = caughtError
-                    }
-#endif
                 } else {
                     error = CouchDBUtils.createError(response.statusCode, id: nil, rev: nil)
                 }


### PR DESCRIPTION
…sh. IBM-Swift/Kitura#1043

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On Linux (Swift 3.1 & 3.0.2), catch the error, and create an NSError from it--instead of doing `catch let err as NSError`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IBM-Swift/Kitura#1043
https://bugs.swift.org/browse/SR-3872
"bridging Error to NSError is NOT ALLOWED on Linux"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
