### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT TESTDB_NAME=testdb_1604_2
+    - os: linux
+      dist: trusty
+      sudo: required
       env: DOCKER_IMAGE=ubuntu:18.04 KITURA_NIO=1 TESTDB_NAME=testdb_1804_1
     - os: osx
       osx_image: xcode9.2
@@ -47,6 +51,10 @@ matrix:
       osx_image: xcode10
       sudo: required
       env: SWIFT_SNAPSHOT=4.2 TESTDB_NAME=testdb_xcode10_1
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT TESTDB_NAME=testdb_xcode10_2
     - os: osx
       osx_image: xcode10
       sudo: required


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.