### PR TITLE
Explicitly pass TESTDB_NAME to Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: DOCKER_IMAGE=ubuntu:16.04 TESTDB_NAME=testdb_1604_1
+      env: DOCKER_IMAGE=ubuntu:16.04 DOCKER_ENVIRONMENT="TESTDB_NAME" TESTDB_NAME=testdb_1604_1
     - os: linux
       dist: trusty
       sudo: required
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT TESTDB_NAME=testdb_1604_2
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT DOCKER_ENVIRONMENT="TESTDB_NAME" TESTDB_NAME=testdb_1604_2
     # - os: linux
     #   dist: trusty
     #   sudo: required
-    #   env: DOCKER_IMAGE=ubuntu:16.04 KITURA_NIO=1 TESTDB_NAME=testdb_1604_3
+    #   env: DOCKER_IMAGE=ubuntu:16.04 KITURA_NIO=1 DOCKER_ENVIRONMENT="TESTDB_NAME" TESTDB_NAME=testdb_1604_3
     - os: linux
       dist: trusty
       sudo: required
-      env: DOCKER_IMAGE=ubuntu:18.04 TESTDB_NAME=testdb_1804_1
+      env: DOCKER_IMAGE=ubuntu:18.04 DOCKER_ENVIRONMENT="TESTDB_NAME" TESTDB_NAME=testdb_1804_1
     - os: osx
       osx_image: xcode9.2
       sudo: required


### PR DESCRIPTION
Uses https://github.com/IBM-Swift/Package-Builder/pull/150, which removes the requirement for Package-Builder to hard-code TESTDB_NAME as a magic environment variable.

(replaces #92 which Travis was rejecting for some reason)