### PR TITLE
Adding a public typealias for Database

### DIFF
--- a/Sources/CouchDB/Database.swift
+++ b/Sources/CouchDB/Database.swift
@@ -19,6 +19,9 @@ import KituraNet
 
 // MARK: Database
 
+// Type Alias for Database (See [Kitura/Swift-Kuery-ORM#22](https://github.com/Kitura/Swift-Kuery-ORM/issues/22))
+public typealias CouchDatabase = Database
+
 /**
  The `Database` class is used to make HTTP requests to the corresponding CouchDB database. This class can make CRUD (Create, Retrieve, Update, Delete) requests for:  
  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a `CouchDatabase` typealias to the `Database` class.

## Motivation and Context
Because of https://github.com/Kitura/Swift-Kuery-ORM/issues/22

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- N/A If applicable, I have updated the documentation accordingly.
- N/A If applicable, I have added tests to cover my changes.
